### PR TITLE
Fix RELEVANT_MAPPING merge

### DIFF
--- a/lib/kitbuilder/pom.rb
+++ b/lib/kitbuilder/pom.rb
@@ -33,7 +33,11 @@ module Kitbuilder
     }
 
     def relevant_mapping
-      RELEVANT_MAPPING.merge(@scopes.map { |s| { s.to_sym => s } })
+      h = Hash.new
+      @scopes.map { |s|
+	      h.merge!({s.to_sym => s})
+      }
+      RELEVANT_MAPPING.merge(h)
     end
 
     # WGETS


### PR DESCRIPTION
Without this fix in place, kit-prepare-for-dist will stacktrace when run on a kit tarball:

```
$ kit-prepare-for-dist.ruby2.5 cassandra-kit.tar.xz
Extracting cassandra-kit.tar.xz
Searching the maven universe
WARNING: Nokogiri was built against LibXML version 2.9.9, but has dynamically loaded 2.9.8
Dir /tmp/d20190311-13899-9g7p81/kit/m2
Removing jars from /tmp/d20190311-13899-9g7p81/kit/m2
Writing /crypt/home/johannes/osc/server:database/cassandra-kit/create-tarball.sh
Looking in /tmp/d20190311-13899-9g7p81/kit/m2
ant version 1.9.7
maven version 3.3.9
Traceback (most recent call last):
        10: from /usr/lib64/ruby/gems/2.5.0/gems/kitbuilder-1.0.0/bin/kitbuilder:116:in `<main>'
         9: from /usr/lib64/ruby/gems/2.5.0/gems/kitbuilder-1.0.0/lib/kitbuilder.rb:133:in `strip'
         8: from /usr/lib64/ruby/gems/2.5.0/gems/kitbuilder-1.0.0/lib/kitbuilder.rb:133:in `chdir'
         7: from /usr/lib64/ruby/gems/2.5.0/gems/kitbuilder-1.0.0/lib/kitbuilder.rb:134:in `block in strip'
         6: from /usr/lib64/ruby/gems/2.5.0/gems/kitbuilder-1.0.0/lib/kitbuilder.rb:134:in `glob'
         5: from /usr/lib64/ruby/gems/2.5.0/gems/kitbuilder-1.0.0/lib/kitbuilder.rb:138:in `block (2 levels) in strip'
         4: from /usr/lib64/ruby/gems/2.5.0/gems/kitbuilder-1.0.0/lib/kitbuilder.rb:69:in `handle_dir'
         3: from /usr/lib64/ruby/gems/2.5.0/gems/kitbuilder-1.0.0/lib/kitbuilder/pom.rb:68:in `find'
         2: from /usr/lib64/ruby/gems/2.5.0/gems/kitbuilder-1.0.0/lib/kitbuilder/repository/repository.rb:28:in `find'
         1: from /usr/lib64/ruby/gems/2.5.0/gems/kitbuilder-1.0.0/lib/kitbuilder/pom.rb:36:in `relevant_mapping'
/usr/lib64/ruby/gems/2.5.0/gems/kitbuilder-1.0.0/lib/kitbuilder/pom.rb:36:in `merge': no implicit conversion of Array into Hash (TypeError)
```

