### PR TITLE
Jarcheck fixes

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -6,6 +6,39 @@
 
 A simpler way to builder -kit for building Java packages
 
+== Generating source packages
+
+The `jarcheck` utility can generate source packages from a
+[Tetra](https://github.com/moio/tetra) kit tarball. To use it, proceed as
+follows:
+
+1. Change to the future source package's directory.
+
+2. Create a directory to unpack the kit tarball in. This directory must be
+   named `<name>-kit`, where `<name>` is the main package's name. Example: if
+   your main package is named `foo`, this directory must be named `foo-kit`.
+
+3. Unpack the kit tarball into the directory created in step (2). Example for a
+   package named `foo`: `tar -C foo-kit -xJf foo-kit.tar.xz`
+
+4. Run `jarcheck`. It takes two (mandatory) arguments: the package's name and
+   the kit package's name. Example for a package named `foo`: `jarcheck foo
+   foo-kit`.
+
+5. You should now find all jars required for a source package, along with a
+   generated source package spec in the current directory. If `jarcheck` cannot
+   find a jar file's source package name or fails to download it, it will
+   output an error message about the package and exit non-zero. The spec will
+   still be generated, but the `Source` file name for this particular jar file
+   will be commented out in the spec.
+
+6. Download all non-retrievable source jars manually and fix the corresponding
+   lines in the spec file.
+
+7. Correct the version in the spec file to match your package's version (this
+   information is not retrievable from the kit tarball, so you will need to fill
+   it in manually).
+
 == Authors
 
 * Klaus Kämpf <kkaempf@suse.de>

--- a/bin/jarcheck
+++ b/bin/jarcheck
@@ -90,6 +90,10 @@ end
 def find_all_jars_under dir
   jars = {}
   Find.find(dir) do |path|
+    # Ignore Maven/Ant shipped by Tetra
+    if path.include?("kit/apache-ant") or path.include?("kit/apache-maven")
+      next
+    end
     b = File.basename path
     if b =~ /.*\.jar/
       if jars[b]
@@ -194,7 +198,11 @@ rpm_jars.each do |jar|
 #      puts "#{jar}: #{spec}"
       result[jar] = spec
     else
-      STDERR.puts "*** No spec #{jar}:#{jarpath}"
+      # Doesn't matter if we do not have a spec for jars in the apache-ant or
+      # apache-maven directories shipped by Tetra itself.
+      unless jarpath.include?("kit/apache-ant") or jarpath.include?("kit/apache-maven")
+        STDERR.puts "*** No spec #{jar}:#{jarpath}"
+      end
     end
   end
 end
@@ -202,10 +210,7 @@ end
 puts "#{rpm_jars.size} rpm jars, #{result.size} tracked"
 
 unresolved = rpm_jars - result.keys
-
-unresolved.each do |jar|
-  STDERR.puts "*** Unresolved #{jar}"
-end
+download_failed = []
 
 Kitbuilder::Pom.destination = File.join(Dir.pwd, "jars")
 
@@ -221,9 +226,26 @@ result.each do |jar,pomspec|
   if sourcesfile
     spec.add_source sourcesfile
   else
-    STDERR.puts "*** Not found: #{pomspec}"
-    spec.add_source "# #{pomspec}"
+    # We may have .sha1 files in there, so skip everything that's not jar.
+    unless jar.end_with?('.jar')
+      next
+    end
+    STDERR.puts "*** Source download failed: #{pomspec}"
+    spec.add_source "# #{pomspec} # Source download failed"
+    download_failed.push jar
   end    
 end
 
 spec.write
+
+unless unresolved.empty? and download_failed.empty?
+  unresolved.each do |jar|
+    STDERR.puts "*** Unresolved: #{jar}"
+    spec.add_source "# #{File.basename jar} # Unresolved"
+  end
+
+  download_failed.each do |jar|
+    STDERR.puts "*** Source download failed for #{jar}"
+  end
+  exit 1
+end

--- a/bin/jarcheck
+++ b/bin/jarcheck
@@ -54,6 +54,7 @@ def help msg = nil
   STDERR.puts "Usage:"
   STDERR.puts "jarcheck <name> [<unpacked-rpm>] [<pomspec>]"
   STDERR.puts "to check all jars packaged in <name>*"
+  STDERR.puts "Put the kit tarball's kit/ directory into <name>-kit/"
   exit((msg)?1:0)
 end
 
@@ -93,7 +94,7 @@ def find_all_jars_under dir
     if b =~ /.*\.jar/
       if jars[b]
         STDERR.puts "Dup #{path},#{jars[b]}"
-        return nil
+        next
       end
       jars[b] = path
     end
@@ -205,8 +206,6 @@ unresolved = rpm_jars - result.keys
 unresolved.each do |jar|
   STDERR.puts "*** Unresolved #{jar}"
 end
-
-exit 1 unless unresolved.empty?
 
 Kitbuilder::Pom.destination = File.join(Dir.pwd, "jars")
 

--- a/bin/jarcheck
+++ b/bin/jarcheck
@@ -31,7 +31,10 @@ class Spec
 
   def add_source source
     puts "spec.add_source #{source}"
-    @sources << source
+    # Avoid duplicates
+    unless @sources.include? source
+      @sources << source
+    end
   end
 
   def write


### PR DESCRIPTION
This pull request fixes various things I stumbled upon when applying jarcheck to [Spark](https://build.opensuse.org/package/show/Cloud:OpenStack:Master/spark) and adds documentation on on generating source packages from kit tarballs.